### PR TITLE
Enable AT24C32 EEPROM on DS3231

### DIFF
--- a/overlays/meson-gxl-s905x-libretech-cc-ds3231-i2c-ao.dts
+++ b/overlays/meson-gxl-s905x-libretech-cc-ds3231-i2c-ao.dts
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2017 BayLibre, SAS.
  * Author: Neil Armstrong <narmstrong@baylibre.com>
+ * Author: Thomas Rohloff <v10lator@myway.de>
  *
  * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
  */
 
 /*
- * Overlay aimed to add an DS3231 RTC module on I2C_AO bus, address 0x68.
+ * Overlay aimed to add an DS3231 RTC module on I2C_AO bus, address 0x57 and 0x68.
  */
 
 /dts-v1/;
@@ -22,6 +23,10 @@
 			rtc@68 {
 				compatible = "maxim,ds3231";
 				reg = <0x68>;
+			};
+			at24@57 {
+				compatible = "at,24c32";
+				reg = <0x57>;
 			};
 		};
 	};

--- a/overlays/meson-gxl-s905x-libretech-cc-ds3231-i2c-b.dts
+++ b/overlays/meson-gxl-s905x-libretech-cc-ds3231-i2c-b.dts
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2017 BayLibre, SAS.
  * Author: Neil Armstrong <narmstrong@baylibre.com>
+ * Author: Thomas Rohloff <v10lator@myway.de>
  *
  * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
  */
 
 /*
- * Overlay aimed to add an DS3231 RTC module on I2C_B bus, address 0x68.
+ * Overlay aimed to add an DS3231 RTC module on I2C_AO bus, address 0x57 and 0x68.
  */
 
 /dts-v1/;
@@ -22,6 +23,10 @@
 			rtc@68 {
 				compatible = "maxim,ds3231";
 				reg = <0x68>;
+			};
+			at24@57 {
+				compatible = "at,24c32";
+				reg = <0x57>;
 			};
 		};
 	};


### PR DESCRIPTION
The DS3231 is a DS1307 with added temp sensor and EEPROM. Make use of the EEPROM.

Signed-off-by: V10lator <v10lator@myway.de>