### PR TITLE
Add overlays for AT24C32 EEPROM

### DIFF
--- a/overlays/meson-gxl-s905x-libretech-cc-at24c32-i2c-ao.dts
+++ b/overlays/meson-gxl-s905x-libretech-cc-at24c32-i2c-ao.dts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2017 BayLibre, SAS.
+ * Author: Thomas Rohloff <v10lator@myway.de>
+ *
+ * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ */
+
+/*
+ * Overlay aimed to add an AT24C32 EEPROM module on I2C_AO bus, address 0x57.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "libretech,cc", "amlogic,s905x", "amlogic,meson-gxl";
+
+	fragment@1 {
+		target = <&i2c_AO>;
+		
+		__overlay__ {
+			eeprom@57 {
+				compatible = "at,24c32";
+				reg = <0x57>;
+			};
+		};
+	};
+};

--- a/overlays/meson-gxl-s905x-libretech-cc-at24c32-i2c-b.dts
+++ b/overlays/meson-gxl-s905x-libretech-cc-at24c32-i2c-b.dts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2017 BayLibre, SAS.
+ * Author: Thomas Rohloff <v10lator@myway.de>
+ *
+ * SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ */
+
+/*
+ * Overlay aimed to add an AT24C32 EEPROM module on I2C_B bus, address 0x57.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "libretech,cc", "amlogic,s905x", "amlogic,meson-gxl";
+
+	fragment@1 {
+		target = <&i2c_B>;
+		
+		__overlay__ {
+			eeprom@57 {
+				compatible = "at,24c32";
+				reg = <0x57>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
as often found coupled with DS3231 RTC modules

Signed-off-by: V10lator <v10lator@myway.de>